### PR TITLE
Get sr each patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,4 +155,5 @@ Still under development. Use with caution.
 
 ## Contact
 Ahmad Tourei, Colorado School of Mines
+
 tourei@mines.edu | ahmadtourei@gmail.com

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ AnomalyDetector(cfg).run_parallel()
 
 # count number of anomalies
 cfg = CounterConfig(keyword="anomaly")
-AnomalyCounter(cfg).run() # prints info on number of anomalies and path to them
+anomalies = AnomalyCounter(cfg).run() 
+print(anomalies) # prints info on number of anomalies and path to them
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The main steps for using the package are as follows:
 1. Define constants and create a Spool of data: 
 Using the _config_user_ script in the das_anomaly directory, define the constants and directory paths for data, power spectral density (PSD) images, detected anomaly results, etc. You would complete adding the values as you go over the steps mentioned below.
 
-Then, using DASCore, create an index file for the spool of data first time reading the DAS data directory:
+Then, using DASCore, create an index file for the [spool](https://dascore.org/tutorial/spool.html) of data first time reading the DAS data directory:
 ### Example
 ```python
 import dascore as dc
@@ -69,6 +69,8 @@ data_path = SETTINGS.DATA_PATH
 # Update will create an index of the contents for fast querying/access
 spool = dc.spool(directory_path).update()
 ``` 
+Note: Creating the spool for the first time may take some time if your directory contains hundreds of gigabytes or terabytes of DAS data. However, DASCore creates an index file, allowing it to quickly query the directory on subsequent accesses.
+
 2. Set a consistent upper bound for PSD amplitude values:
 To ensure all PSD images share the same colorbar scale, determine an appropriate CLIP_VALUE_MAX in the _config_user_ script. This can be done using the `get_psd_max_clip` function, which computes the mean value of maximum amplitude from TIME_WINDOWs of the data which does not include drastic anomalies (therefore, a quick exploratory data analysis is needed here.)
 ### Example

--- a/das_anomaly/count/counter.py
+++ b/das_anomaly/count/counter.py
@@ -9,7 +9,8 @@ Example
 -------
 >>> from das_anomaly.count.counter import CounterConfig, AnomalyCounter
 >>> cfg = CounterConfig(keyword="anomaly")
->>> AnomalyCounter(cfg).run()
+>>> anomalies = AnomalyCounter(cfg).run()
+>>> print(anomalies)
 """
 
 from __future__ import annotations

--- a/das_anomaly/count/counter.py
+++ b/das_anomaly/count/counter.py
@@ -8,8 +8,8 @@ Count how many lines in the *results* folder contain the keyword
 Example
 -------
 >>> from das_anomaly.count.counter import CounterConfig, AnomalyCounter
->>> total = AnomalyCounter(CounterConfig(keyword="anomaly")).run()
->>> print(total)
+>>> cfg = CounterConfig(keyword="anomaly")
+>>> AnomalyCounter(cfg).run()
 """
 
 from __future__ import annotations

--- a/das_anomaly/psd/generator.py
+++ b/das_anomaly/psd/generator.py
@@ -128,9 +128,6 @@ class PSDGenerator:
         data_path = self.cfg.data_path
         sp = dc.spool(data_path).update()
 
-        patch0 = sp[0]
-        sr = self._sampling_rate(patch0)
-
         if select_time:
             sub_sp_time = sp.select(time=(self.cfg.t1, self.cfg.t2))
             sub_sp_time_distance = sub_sp_time.select(
@@ -150,6 +147,7 @@ class PSDGenerator:
             )
         # iterate over patches and perform preprocessing
         for patch in sub_sp_chunked:
+            sr = self._sampling_rate(patch)
             if self.cfg.data_unit == "velocity":
                 yield (
                     patch.velocity_to_strain_rate_edgeless(

--- a/das_anomaly/psd/generator.py
+++ b/das_anomaly/psd/generator.py
@@ -269,6 +269,9 @@ class PSDGenerator:
             t = patch.coords["time"]
             time_step = (t.max() - t.min()) / (len(t) - 1)
             dt_seconds = float(time_step / np.timedelta64(1, "s"))
+        else:
+            # Assume time_Step is already an int or float in seconds
+            dt_seconds = float(time_step)
 
         if dt_seconds == 0:
             raise ValueError("Time step is zero; cannot compute sampling rate.")

--- a/das_anomaly/psd/generator.py
+++ b/das_anomaly/psd/generator.py
@@ -261,12 +261,14 @@ class PSDGenerator:
         """
         time_step = patch.coords.step("time")
 
-        # timedelta64  ➜  seconds as float
         if isinstance(time_step, np.timedelta64):
+            # timedelta64  ➜  seconds as float
             dt_seconds = time_step / np.timedelta64(1, "s")
-        else:
-            # assume numeric seconds (int, float, or numpy scalar)
-            dt_seconds = float(time_step)
+        elif time_step is None:
+            # infer ∆t from the time coordinate
+            t = patch.coords["time"]
+            time_step = (t.max() - t.min()) / (len(t) - 1)
+            dt_seconds = float(time_step / np.timedelta64(1, "s"))
 
         if dt_seconds == 0:
             raise ValueError("Time step is zero; cannot compute sampling rate.")

--- a/examples/exclude_known_events_from_training/find_event_time_from_excel_Sheet.ipynb
+++ b/examples/exclude_known_events_from_training/find_event_time_from_excel_Sheet.ipynb
@@ -109,8 +109,8 @@
     "    png_file_paths_total.extend(find_png_files(d))\n",
     "\n",
     "# show the paths (optional)\n",
-    "for p in png_file_paths_total:\n",
-    "    print(p)\n",
+    "# for p in png_file_paths_total:\n",
+    "#     print(p)\n",
     "\n",
     "print(\"number of all files =\", len(png_file_paths_total))"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ max-complexity = 10
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.ruff.per-file-ignores]          # ← keep this *after* the main settings
+[tool.ruff.per-file-ignores]         
 "tests/**/*.py" = [
   "D100","D101","D102","D103","D104","D105","D107",
 ]


### PR DESCRIPTION
`_sampling_rate` helper function could crash on chunked patches because `patch.coords.step("time")` sometimes returns None. This PR resolves this issue by adding robust sampling rate calculation directly.

See [DASCore issue 509](https://github.com/DASDAE/dascore/issues/509) for more details regarding DASCore failure in calculating `patch.coords.step("time")` for some patches after chunking.