### PR TITLE
feat: make encoder layer count configurable

### DIFF
--- a/das_anomaly/config_defaults.py
+++ b/das_anomaly/config_defaults.py
@@ -18,6 +18,8 @@ T_2 = "2022-12-08 00:00:00"
 
 # Size of the input/output images
 SIZE = 128
+# Number of layers in the encoder (and the symmetric decoder)
+LAYERS = 3
 # Batch size for the train generator
 BATCH_SIZE = 64
 # Desired density threshold based on density score

--- a/das_anomaly/config_user.py
+++ b/das_anomaly/config_user.py
@@ -18,6 +18,8 @@ T_2 = "2023-02-00 00:00:00"
 
 # Size of the input/output images
 SIZE = 512
+# Number of layers in the encoder (and the symmetric decoder)
+LAYERS = 3
 # Batch size for the train generator
 BATCH_SIZE = 64
 # Desired density threshold based on density score

--- a/das_anomaly/train/autoencoder.py
+++ b/das_anomaly/train/autoencoder.py
@@ -40,6 +40,7 @@ class TrainAEConfig:
 
     # data & training parameters
     img_size: int = SETTINGS.SIZE
+    num_layers: int = SETTINGS.LAYERS
     batch_size: int = SETTINGS.BATCH_SIZE
     num_epoch: int = SETTINGS.NUM_EPOCH
 
@@ -112,12 +113,12 @@ class AutoencoderTrainer:
         model.compile(
             optimizer="adam",
             loss="mean_squared_error",
-            metrics=["mse"],
+            metrics=["mae"],  # mean absolute error
         )
         return model
 
     def _build_model(self):
-        enc = encoder(self.cfg.img_size)
+        enc = encoder(self.cfg.img_size, self.cfg.num_layers)
         dec = decoder(enc)
         return self._compile(dec)
 

--- a/tests/test_train/test_autoencoder.py
+++ b/tests/test_train/test_autoencoder.py
@@ -12,6 +12,7 @@ def dummy_cfg(tmp_path):
         test_dir=tmp_path / "test",
         out_dir=tmp_path / "out",
         img_size=32,
+        num_layers=2,
         batch_size=2,
         num_epoch=1,
     )
@@ -27,7 +28,7 @@ def test_trainer_build_and_save(monkeypatch, dummy_cfg):
     fake_model.layers[0].save = MagicMock()
 
     monkeypatch.setattr(
-        "das_anomaly.train.autoencoder.encoder", lambda size: fake_model
+        "das_anomaly.train.autoencoder.encoder", lambda *args, **kwargs: fake_model
     )
     monkeypatch.setattr("das_anomaly.train.autoencoder.decoder", lambda model: model)
     monkeypatch.setattr(
@@ -63,7 +64,9 @@ def test_saved_files(tmp_path, monkeypatch):
     keras_model = MagicMock(name="Model")
     keras_model.fit.return_value.history = fake_hist
     keras_model.layers = [MagicMock(name="Encoder")]
-    monkeypatch.setattr("das_anomaly.train.autoencoder.encoder", lambda s: keras_model)
+    monkeypatch.setattr(
+        "das_anomaly.train.autoencoder.encoder", lambda *args, **kwargs: keras_model
+    )
     monkeypatch.setattr("das_anomaly.train.autoencoder.decoder", lambda m: m)
     monkeypatch.setattr(
         "das_anomaly.train.autoencoder.ImageDataGenerator",


### PR DESCRIPTION
This PR makes the encoder's layer count configurable. It also replaces the trackable "mse" metric with "mae" (mean absolute error) for compiling the model as the previous mse was redundant given "mse" as the default for loss (objective function).